### PR TITLE
FIX removing and entry could accidentally clear the whole tree

### DIFF
--- a/src/RTree/RTree.cs
+++ b/src/RTree/RTree.cs
@@ -204,7 +204,7 @@ namespace Enyim.Collections
 			}
 
 			// adjust bboxes along the insertion path
-			AdjutsParentBounds(envelope, insertPath, level);
+			AdjustParentBounds(envelope, insertPath, level);
 		}
 
 		private static int CombinedArea(Envelope what, Envelope with)
@@ -456,7 +456,7 @@ namespace Enyim.Collections
 			return retval;
 		}
 
-		private static void AdjutsParentBounds(Envelope bbox, List<RTreeNode<T>> path, int level)
+		private static void AdjustParentBounds(Envelope bbox, List<RTreeNode<T>> path, int level)
 		{
 			// adjust bboxes along the given tree path
 			for (var i = level; i >= 0; i--)

--- a/src/RTree/RTree.cs
+++ b/src/RTree/RTree.cs
@@ -416,24 +416,26 @@ namespace Enyim.Collections
 
 		private void CondenseNodes(IList<RTreeNode<T>> path)
 		{
+            var count = path.Count;
+
 			// go through the path, removing empty nodes and updating bboxes
-			for (var i = path.Count - 1; i >= 0; i--)
+			for (var i = 0; i < count; i++)
 			{
-				if (path[i].Children.Count == 0)
+                if (path[i].Children.Count == 0)
 				{
-					if (i == 0)
+                    if (i == count - 1)
 					{
-						Clear();
+                        Clear();
 					}
 					else
 					{
-						var siblings = path[i - 1].Children;
-						siblings.Remove(path[i]);
-					}
+                        var siblings = path[i + 1].Children;
+                        siblings.Remove(path[i]);
+                    }
 				}
 				else
 				{
-					RefreshEnvelope(path[i]);
+                    RefreshEnvelope(path[i]);
 				}
 			}
 		}


### PR DESCRIPTION
This is a snippet from the unit test that triggered the bug.

``` c#
private class Something
{
    public int Id;
    public Envelope Envelope;

    public override int GetHashCode()
    {
        return Id.GetHashCode();
    }

    public override bool Equals(System.Object obj)
    {
        // If parameter is null return false.
        if (obj == null)
        {
            return false;
        }

        if (obj is Something)
        {
            return Id == ((Something)obj).Id;
        }
        else
        {
            return false;
        }
    }

    public bool Equals(Something p)
    {
        // If parameter is null return false:
        if ((object)p == null)
        {
            return false;
        }

        // Return true if the fields match:
        return Id == p.Id;
    }

    public override string ToString()
    {
        return string.Format("[Id={0} Env={1}]", Id, Envelope);
    }
}

[TestMethod]
public void RTreeMass2()
{
    RTree<Something> r = new RTree<Something>();

    List<Something> l = new List<Something>();

    int count = 100;

    for (int i = 0; i < count; ++i)
    {
        int x = 5 - (i % 10);
        int y = 5 - ((i*i) % 10);
        int radius = 1 + i % 5;

        var o = new Something(){
            Id = i,
            Envelope = new Envelope(x-radius, y-radius, x+radius, y+radius),
        };

        l.Add(o);
    }

    // add all
    foreach(var it in l){
        r.Insert(it, it.Envelope);
    }

    // query all
    foreach(var it in l)
    {
        // search
        Assert.AreEqual(true, r.Search(it.Envelope).Any(i => i.Data == it));

        Assert.AreEqual(count, r.Search(new Envelope(-1000, -1000, 1000, 1000)).Count());

        // remove
        r.Remove(it, it.Envelope);
        count--;

        Assert.AreEqual(count, r.Search(new Envelope(-1000, -1000, 1000, 1000)).Count());                
    }

    Assert.AreEqual(count, r.Search(new Envelope(-1000, -1000, 1000, 1000)).Count());                
}
```
